### PR TITLE
add expose FilFox error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Cancel transactions older than `ms`. Returns the return value of
 [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
 for all performed cancellations.
 
+Throws:
+- _See `cancelTx()`_
+- _See `getRecentSendMessage()`_
+- _potentially more_
+
 ### `cancelTx({ tx, recentGasUsed, recentGasFeeCap, log, sendTransaction }) -> Promise<tx>`
 
 ```js
@@ -135,3 +140,8 @@ Helper method that fetches a recent `SendMessage`.
 - `receipt`: `object`
   -  `gasUsed`: `number`
 - `gasFeeCap`: `string`
+
+Throws:
+- `err.code === 'FILFOX_REQUEST_FAILED'`: This method relies on `filfox.info`.
+Requests may fail at any point
+- _potentially more_

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ export const cancelTx = ({
 export const getRecentSendMessage = async () => {
   let res = await fetch('https://filfox.info/api/v1/message/list?method=Send')
   if (!res.ok) {
-    throw new Error(`Filfox request failed with ${res.status}: ${(await res.text()).trimEnd()}`)
+    const err = new Error(`Filfox request failed with ${res.status}: ${(await res.text()).trimEnd()}`)
+    err.code = 'FILFOX_REQUEST_FAILED'
+    throw err
   }
   const body = await res.json()
   assert(body.messages.length > 0, '/message/list returned an empty list')


### PR DESCRIPTION
In order for `spark-evaluate` to ignore FilFox errors, expose them with their own code first.

For https://github.com/filecoin-station/spark-evaluate/pull/363#issuecomment-2372918955