### PR TITLE
fix increase gas limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Throws:
 - _See `getRecentSendMessage()`_
 - _potentially more_
 
-### `cancelTx({ tx, recentGasUsed, recentGasFeeCap, log, sendTransaction }) -> Promise<tx>`
+### `cancelTx({ tx, recentGasLimit, recentGasFeeCap, log, sendTransaction }) -> Promise<tx>`
 
 ```js
 import { cancelTx } from 'cancel-stuck-transactions'
@@ -116,7 +116,7 @@ Helper method that manually cancels transaction `tx`.
 Options:
 
 - `tx`: `ethers.Transaction`
-- `recentGasUsed`: `number`
+- `recentGasLimit`: `number`
 - `recentGasFeeCap`: `bigint`
 - `log`: `(str: string) -> null`
 - `sendTransaction`: `(Transaction) -> Promise<Transaction>`

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Helper method that fetches a recent `SendMessage`.
 - `receipt`: `object`
   -  `gasUsed`: `number`
 - `gasFeeCap`: `string`
+- `gasLimit`: `number`
 
 Throws:
 - `err.code === 'FILFOX_REQUEST_FAILED'`: This method relies on `filfox.info`.

--- a/index.js
+++ b/index.js
@@ -3,18 +3,18 @@ import ms from 'ms'
 
 export const cancelTx = ({
   tx,
-  recentGasUsed,
+  recentGasLimit,
   recentGasFeeCap,
   log,
   sendTransaction
 }) => {
   // Increase by 25% + 1 attoFIL (easier: 25.2%) and round up
   const maxPriorityFeePerGas = (tx.maxPriorityFeePerGas * 1252n + 1000n) / 1000n
-  const gasLimit = Math.ceil(recentGasUsed * 1.1)
+  const gasLimit = Math.ceil(recentGasLimit * 1.1)
 
   log(`Replacing ${tx.hash}...`)
   log(`- maxPriorityFeePerGas: ${tx.maxPriorityFeePerGas} -> ${maxPriorityFeePerGas}`)
-  log(`- gasLimit: ${recentGasUsed} -> ${gasLimit}`)
+  log(`- gasLimit: ${recentGasLimit} -> ${gasLimit}`)
   return sendTransaction({
     to: tx.from,
     value: 0,
@@ -111,17 +111,17 @@ export class StuckTransactionsCanceller {
 
     return Promise.allSettled(txsToCancel.map(tx => this.#cancelTx({
       tx,
-      recentGasUsed: recentSendMessage.receipt.gasUsed,
+      recentGasLimit: recentSendMessage.gasLimit,
       recentGasFeeCap: Number(recentSendMessage.gasFeeCap)
     })))
   }
 
-  async #cancelTx ({ tx, recentGasUsed, recentGasFeeCap }) {
+  async #cancelTx ({ tx, recentGasLimit, recentGasFeeCap }) {
     let replacementTx
     try {
       replacementTx = await cancelTx({
         tx,
-        recentGasUsed,
+        recentGasLimit,
         recentGasFeeCap,
         log: str => this.#log(str),
         sendTransaction: tx => this.#sendTransaction(tx)

--- a/test.js
+++ b/test.js
@@ -224,7 +224,7 @@ test('cancelTx()', async () => {
       nonce: 20,
       from: '0x0'
     },
-    recentGasUsed: 1,
+    recentGasLimit: 1,
     recentGasFeeCap: 11n,
     log: () => {},
     sendTransaction (tx) {


### PR DESCRIPTION
Replacement messages started running out of gas.

Base calculation on recent gas limit (higher) not recent gas used.