### PR TITLE
use original tx gasLimit as lower bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ const stuckTransactionsCanceller = new StuckTransactionsCanceller({
   // Pass a storage adapter, so that pending cancellations are persisted across
   // process restarts
   store: {
-    async set ({ hash, timestamp, from, maxPriorityFeePerGas, nonce }) {
+    async set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
       await fs.writeFile(
         `transactions/${hash}`,
-        JSON.stringify({ hash, timestamp, from, maxPriorityFeePerGas, nonce })
+        JSON.stringify({
+          hash,
+          timestamp,
+          from,
+          maxPriorityFeePerGas,
+          gasLimit,
+          nonce
+        })
       )
     },
     async list () {
@@ -76,7 +83,7 @@ import { StuckTransactionsCanceller } from 'cancel-stuck-transactions'
 Options:
 
 - `store`:
-  - `store.set`: `({ hash: string, timestamp: string, from: string, maxPriorityFeePerGas: bigint, nonce: number }) -> Promise`
+  - `store.set`: `({ hash: string, timestamp: string, from: string, maxPriorityFeePerGas: bigint, gasLimit: bigint, nonce: number }) -> Promise`
   - `store.list`: `() -> Promise<{ hash: string, timestamp: string, from: string, maxPriorityFeePerGas: bigint, nonce: number }[]>`
   - `store.remove`: `(hash: string) -> Promise`
 - `log`: `(string) -> null`

--- a/example.js
+++ b/example.js
@@ -14,12 +14,13 @@ const signer = ethers.Wallet.fromPhrase(WALLET_SEED).connect(provider)
 const storage = new Map()
 const stuckTransactionsCanceller = new StuckTransactionsCanceller({
   store: {
-    set ({ hash, timestamp, from, maxPriorityFeePerGas, nonce }) {
+    set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
       storage.set(hash, {
         hash,
         timestamp,
         from,
         maxPriorityFeePerGas,
+        gasLimit,
         nonce
       })
     },

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ export const cancelTx = ({
 }) => {
   // Increase by 25% + 1 attoFIL (easier: 25.2%) and round up
   const maxPriorityFeePerGas = (tx.maxPriorityFeePerGas * 1252n + 1000n) / 1000n
-  const gasLimit = Math.ceil(recentGasLimit * 1.1)
+  const gasLimit = Math.ceil(Math.max(Number(tx.gasLimit), recentGasLimit) * 1.1)
 
   log(`Replacing ${tx.hash}...`)
   log(`- maxPriorityFeePerGas: ${tx.maxPriorityFeePerGas} -> ${maxPriorityFeePerGas}`)
-  log(`- gasLimit: ${recentGasLimit} -> ${gasLimit}`)
+  log(`- gasLimit: ${tx.gasLimit} -> ${gasLimit}`)
   return sendTransaction({
     to: tx.from,
     value: 0,
@@ -68,6 +68,7 @@ export class StuckTransactionsCanceller {
     assert.strictEqual(typeof tx.hash, 'string')
     assert.strictEqual(typeof tx.from, 'string')
     assert.strictEqual(typeof tx.maxPriorityFeePerGas, 'bigint')
+    assert.strictEqual(typeof tx.gasLimit, 'bigint')
     assert.strictEqual(typeof tx.nonce, 'number')
     await this.#store.set({
       ...tx,

--- a/test.js
+++ b/test.js
@@ -15,24 +15,27 @@ test('StuckTransactionsCanceller', async t => {
     const tx = {
       hash: 'hash',
       maxPriorityFeePerGas: 10n,
+      gasLimit: 1n,
       nonce: 20,
       from: '0x0'
     }
     const storage = new Map()
     const stuckTransactionsCanceller = new StuckTransactionsCanceller({
       store: {
-        set ({ hash, timestamp, from, maxPriorityFeePerGas, nonce }) {
+        set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
           assert(!storage.has(hash))
           assert.strictEqual(typeof hash, 'string')
           assert.strictEqual(typeof timestamp, 'string')
           assert.strictEqual(typeof from, 'string')
           assert.strictEqual(typeof maxPriorityFeePerGas, 'bigint')
+          assert.strictEqual(typeof gasLimit, 'bigint')
           assert.strictEqual(typeof nonce, 'number')
           storage.set(hash, {
             hash,
             timestamp,
             from,
             maxPriorityFeePerGas,
+            gasLimit,
             nonce
           })
         },
@@ -60,6 +63,7 @@ test('StuckTransactionsCanceller', async t => {
       hash: tx.hash,
       from: tx.from,
       maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+      gasLimit: tx.gasLimit,
       nonce: tx.nonce
     })
   })
@@ -68,6 +72,7 @@ test('StuckTransactionsCanceller', async t => {
       const tx = {
         hash: 'hash',
         maxPriorityFeePerGas: 10n,
+        gasLimit: 1n,
         nonce: 20,
         from: '0x0'
       }
@@ -75,13 +80,14 @@ test('StuckTransactionsCanceller', async t => {
       const sentTransactions = []
       const stuckTransactionsCanceller = new StuckTransactionsCanceller({
         store: {
-          set ({ hash, timestamp, from, maxPriorityFeePerGas, nonce }) {
+          set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
             assert(!storage.has(hash))
             storage.set(hash, {
               hash,
               timestamp,
               from,
               maxPriorityFeePerGas,
+              gasLimit,
               nonce
             })
           },
@@ -111,6 +117,7 @@ test('StuckTransactionsCanceller', async t => {
     const tx = {
       hash: 'hash',
       maxPriorityFeePerGas: 10n,
+      gasLimit: 1n,
       nonce: 20,
       from: '0x0'
     }
@@ -118,13 +125,14 @@ test('StuckTransactionsCanceller', async t => {
     const sentTransactions = []
     const stuckTransactionsCanceller = new StuckTransactionsCanceller({
       store: {
-        set ({ hash, timestamp, from, maxPriorityFeePerGas, nonce }) {
+        set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
           assert(!storage.has(hash))
           storage.set(hash, {
             hash,
             timestamp,
             from,
             maxPriorityFeePerGas,
+            gasLimit,
             nonce
           })
         },
@@ -158,10 +166,10 @@ test('StuckTransactionsCanceller', async t => {
     }])
     assert.strictEqual(sentTransactions.length, 1)
     const sentTransactionClone = { ...sentTransactions[0] }
-    assert(sentTransactionClone.gasLimit)
     assert(sentTransactionClone.maxFeePerGas)
-    delete sentTransactionClone.gasLimit
+    assert(sentTransactionClone.gasLimit)
     delete sentTransactionClone.maxFeePerGas
+    delete sentTransactionClone.gasLimit
     assert.deepStrictEqual(sentTransactionClone, {
       maxPriorityFeePerGas: 13n,
       nonce: tx.nonce,
@@ -174,19 +182,21 @@ test('StuckTransactionsCanceller', async t => {
     const tx = {
       hash: 'hash',
       maxPriorityFeePerGas: 10n,
+      gasLimit: 1n,
       nonce: 20,
       from: '0x0'
     }
     const storage = new Map()
     const stuckTransactionsCanceller = new StuckTransactionsCanceller({
       store: {
-        set ({ hash, timestamp, from, maxPriorityFeePerGas, nonce }) {
+        set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
           assert(!storage.has(hash))
           storage.set(hash, {
             hash,
             timestamp,
             from,
             maxPriorityFeePerGas,
+            gasLimit,
             nonce
           })
         },
@@ -221,6 +231,7 @@ test('cancelTx()', async () => {
     tx: {
       hash: 'hash',
       maxPriorityFeePerGas: 10n,
+      gasLimit: 1n,
       nonce: 20,
       from: '0x0'
     },


### PR DESCRIPTION
It is possible for the recent send message to have a way lower gas limit than the original tx we want to replace. Especially with smart contracts.

We could probably remove reading the gas limit from a recent send message altogether, however I'd like to play it safe for now.