### PR TITLE
Add recursive canceling

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ export class StuckTransactionsCanceller {
         log: str => this.#log(str),
         sendTransaction: tx => this.#sendTransaction(tx)
       })
+      await this.addPending(replacementTx)
     } catch (err) {
       if (err.code === 'NONCE_EXPIRED') {
         this.#log(`${tx.hash} has already been confirmed`)

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ export const cancelTx = ({
 }) => {
   // Increase by 25% + 1 attoFIL (easier: 25.2%) and round up
   const maxPriorityFeePerGas = (tx.maxPriorityFeePerGas * 1252n + 1000n) / 1000n
-  const gasLimit = Math.ceil(Math.max(Number(tx.gasLimit), recentGasLimit) * 1.1)
+  const gasLimit = BigInt(Math.ceil(Math.max(Number(tx.gasLimit), recentGasLimit) * 1.1))
 
   log(`Replacing ${tx.hash}...`)
   log(`- maxPriorityFeePerGas: ${tx.maxPriorityFeePerGas} -> ${maxPriorityFeePerGas}`)

--- a/index.js
+++ b/index.js
@@ -92,9 +92,9 @@ export class StuckTransactionsCanceller {
 
     this.#log('Checking for stuck transactions...')
     const txs = await this.#store.list()
-    const txsToCancel = txs.filter(tx => {
-      return new Date() - new Date(tx.timestamp) > ageMs
-    })
+    const txsToCancel = txs
+      .filter(tx => new Date() - new Date(tx.timestamp) > ageMs)
+      .filter(tx => !txs.find(_tx => _tx.nonce === tx.nonce && _tx.gasLimit > tx.gasLimit))
     if (txsToCancel.length === 0) {
       this.#log('No transactions to cancel')
       return

--- a/index.js
+++ b/index.js
@@ -147,7 +147,6 @@ export class StuckTransactionsCanceller {
       `Waiting for receipt of replacing ${tx.hash} with ${replacementTx.hash}...`
     )
     await replacementTx.wait()
-    await this.removeConfirmed(replacementTx)
     await this.removeConfirmed(tx)
     this.#log(`Replaced ${tx.hash} with ${replacementTx.hash}`)
   }

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ export class StuckTransactionsCanceller {
     const txsToCancel = txs
       .filter(tx => new Date() - new Date(tx.timestamp) > ageMs)
       // Ignore transactions that are already being replaced
-      .filter(tx => !txs.find(_tx => _tx.nonce === tx.nonce && _tx.gasLimit > tx.gasLimit))
+      .filter(tx => !txs.some(_tx => _tx.nonce === tx.nonce && _tx.gasLimit > tx.gasLimit))
     if (txsToCancel.length === 0) {
       this.#log('No transactions to cancel')
       return

--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ export class StuckTransactionsCanceller {
       Waiting for receipt of replacing ${tx.hash} with ${replacementTx.hash}...`
     )
     await replacementTx.wait()
+    await this.removeConfirmed(replacementTx)
     await this.#store.remove(tx.hash)
     this.#log(`Replaced ${tx.hash} with ${replacementTx.hash}`)
   }

--- a/index.js
+++ b/index.js
@@ -79,7 +79,12 @@ export class StuckTransactionsCanceller {
 
   async removeConfirmed (tx) {
     assert.strictEqual(typeof tx.hash, 'string')
-    await this.#store.remove(tx.hash)
+    const txs = await this.#store.list()
+    for (const _tx of txs) {
+      if (_tx.nonce === tx.nonce) {
+        await this.#store.remove(_tx.hash)
+      }
+    }
   }
 
   async cancelOlderThan (ageMs) {

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ export class StuckTransactionsCanceller {
     const txs = await this.#store.list()
     const txsToCancel = txs
       .filter(tx => new Date() - new Date(tx.timestamp) > ageMs)
+      // Ignore transactions that are already being replaced
       .filter(tx => !txs.find(_tx => _tx.nonce === tx.nonce && _tx.gasLimit > tx.gasLimit))
     if (txsToCancel.length === 0) {
       this.#log('No transactions to cancel')

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ export const cancelTx = ({
   log(`- maxPriorityFeePerGas: ${tx.maxPriorityFeePerGas} -> ${maxPriorityFeePerGas}`)
   log(`- gasLimit: ${tx.gasLimit} -> ${gasLimit}`)
   return sendTransaction({
+    from: tx.from,
     to: tx.from,
     value: 0,
     nonce: tx.nonce,

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ export class StuckTransactionsCanceller {
     } catch (err) {
       if (err.code === 'NONCE_EXPIRED') {
         this.#log(`${tx.hash} has already been confirmed`)
-        await this.#store.remove(tx.hash)
+        await this.removeConfirmed(tx)
         return
       } else {
         throw err
@@ -143,7 +143,7 @@ export class StuckTransactionsCanceller {
     )
     await replacementTx.wait()
     await this.removeConfirmed(replacementTx)
-    await this.#store.remove(tx.hash)
+    await this.removeConfirmed(tx)
     this.#log(`Replaced ${tx.hash} with ${replacementTx.hash}`)
   }
 }

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ export class StuckTransactionsCanceller {
     const txs = await this.#store.list()
     for (const _tx of txs) {
       if (_tx.nonce === tx.nonce) {
+        this.#log(`Resolved ${_tx.hash} (confirmed or replaced)`)
         await this.#store.remove(_tx.hash)
       }
     }

--- a/index.js
+++ b/index.js
@@ -143,8 +143,8 @@ export class StuckTransactionsCanceller {
         throw err
       }
     }
-    this.#log(`
-      Waiting for receipt of replacing ${tx.hash} with ${replacementTx.hash}...`
+    this.#log(
+      `Waiting for receipt of replacing ${tx.hash} with ${replacementTx.hash}...`
     )
     await replacementTx.wait()
     await this.removeConfirmed(replacementTx)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "debug": "^4.3.7",
         "ethers": "^6.13.2",
+        "p-defer": "^4.0.1",
         "standard": "^17.1.2"
       }
     },
@@ -2453,6 +2454,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "debug": "^4.3.7",
     "ethers": "^6.13.2",
+    "p-defer": "^4.0.1",
     "standard": "^17.1.2"
   },
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -203,7 +203,7 @@ test('StuckTransactionsCanceller', async t => {
           })
         },
         list () {
-          throw new Error('Should not be called')
+          return [...storage.values()]
         },
         remove (hash) {
           assert(storage.has(hash))
@@ -221,6 +221,7 @@ test('StuckTransactionsCanceller', async t => {
     })
 
     await stuckTransactionsCanceller.addPending(tx)
+    await stuckTransactionsCanceller.addPending({ ...tx, hash: 'replacementTxHash' })
     await stuckTransactionsCanceller.removeConfirmed(tx)
     assert.deepStrictEqual(storage, new Map())
   })

--- a/test.js
+++ b/test.js
@@ -245,7 +245,7 @@ test('cancelTx()', async () => {
   })
   assert.strictEqual(replacementTxReturn, replacementTx)
   assert.deepStrictEqual(sentTransactions, [{
-    gasLimit: 2,
+    gasLimit: 2n,
     maxFeePerGas: 13n,
     maxPriorityFeePerGas: 13n,
     nonce: 20,

--- a/test.js
+++ b/test.js
@@ -249,6 +249,7 @@ test('cancelTx()', async () => {
     maxFeePerGas: 13n,
     maxPriorityFeePerGas: 13n,
     nonce: 20,
+    from: '0x0',
     to: '0x0',
     value: 0
   }])

--- a/test.js
+++ b/test.js
@@ -177,8 +177,7 @@ test('StuckTransactionsCanceller', async t => {
         to: tx.from,
         value: 0
       })
-      assert(storage.has('replacementTxHash'))
-      assert(!storage.has(tx.hash))
+      assert.deepStrictEqual(storage, new Map())
     })
   })
   await t.test('#removeConfirmed()', async t => {

--- a/test.js
+++ b/test.js
@@ -222,8 +222,11 @@ test('StuckTransactionsCanceller', async t => {
 
     await stuckTransactionsCanceller.addPending(tx)
     await stuckTransactionsCanceller.addPending({ ...tx, hash: 'replacementTxHash' })
+    await stuckTransactionsCanceller.addPending({ ...tx, hash: 'replacementTxHash2', nonce: 21 })
     await stuckTransactionsCanceller.removeConfirmed(tx)
-    assert.deepStrictEqual(storage, new Map())
+    assert(!storage.has(tx.hash))
+    assert(!storage.has('replacementTxHash'))
+    assert(storage.has('replacementTxHash2'))
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -112,71 +112,74 @@ test('StuckTransactionsCanceller', async t => {
       assert.deepStrictEqual(sentTransactions, [])
       assert(storage.has(tx.hash))
     })
-  })
-  await t.test('cancel old transactions', async t => {
-    const tx = {
-      hash: 'hash',
-      maxPriorityFeePerGas: 10n,
-      gasLimit: 1n,
-      nonce: 20,
-      from: '0x0'
-    }
-    const storage = new Map()
-    const sentTransactions = []
-    const stuckTransactionsCanceller = new StuckTransactionsCanceller({
-      store: {
-        set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
-          assert(!storage.has(hash))
-          storage.set(hash, {
-            hash,
-            timestamp,
-            from,
-            maxPriorityFeePerGas,
-            gasLimit,
-            nonce
-          })
-        },
-        list () {
-          return [...storage.values()]
-        },
-        remove (hash) {
-          assert(storage.has(hash))
-          assert.strictEqual(typeof hash, 'string')
-          storage.delete(hash)
-        }
-      },
-      log: str => {
-        // TODO: Test logs
-        debug(str)
-      },
-      sendTransaction (tx) {
-        sentTransactions.push(tx)
-        return {
-          hash: 'replacementTxHash',
-          wait: () => {}
-        }
+    await t.test('cancel old transactions', async t => {
+      const tx = {
+        hash: 'hash',
+        maxPriorityFeePerGas: 10n,
+        gasLimit: 1n,
+        nonce: 20,
+        from: '0x0'
       }
+      const storage = new Map()
+      const sentTransactions = []
+      const stuckTransactionsCanceller = new StuckTransactionsCanceller({
+        store: {
+          set ({ hash, timestamp, from, maxPriorityFeePerGas, gasLimit, nonce }) {
+            assert(!storage.has(hash))
+            storage.set(hash, {
+              hash,
+              timestamp,
+              from,
+              maxPriorityFeePerGas,
+              gasLimit,
+              nonce
+            })
+          },
+          list () {
+            return [...storage.values()]
+          },
+          remove (hash) {
+            assert(storage.has(hash))
+            assert.strictEqual(typeof hash, 'string')
+            storage.delete(hash)
+          }
+        },
+        log: str => {
+          // TODO: Test logs
+          debug(str)
+        },
+        sendTransaction (tx) {
+          sentTransactions.push(tx)
+          return {
+            ...tx,
+            hash: 'replacementTxHash',
+            wait: () => {}
+          }
+        }
+      })
+      await stuckTransactionsCanceller.addPending(tx)
+      await timers.setImmediate()
+      const status = await stuckTransactionsCanceller.cancelOlderThan(0)
+      assert.deepStrictEqual(status, [{
+        status: 'fulfilled',
+        value: undefined
+      }])
+      assert.strictEqual(sentTransactions.length, 1)
+      const sentTransactionClone = { ...sentTransactions[0] }
+      assert(sentTransactionClone.maxFeePerGas)
+      assert(sentTransactionClone.gasLimit)
+      delete sentTransactionClone.maxFeePerGas
+      delete sentTransactionClone.gasLimit
+      assert.deepStrictEqual(sentTransactionClone, {
+        maxPriorityFeePerGas: 13n,
+        nonce: tx.nonce,
+        from: tx.from,
+        to: tx.from,
+        value: 0
+      })
+      assert(storage.has('replacementTxHash'))
+      assert(!storage.has(tx.hash))
     })
-    await stuckTransactionsCanceller.addPending(tx)
-    await timers.setImmediate()
-    const status = await stuckTransactionsCanceller.cancelOlderThan(0)
-    assert.deepStrictEqual(status, [{
-      status: 'fulfilled',
-      value: undefined
-    }])
-    assert.strictEqual(sentTransactions.length, 1)
-    const sentTransactionClone = { ...sentTransactions[0] }
-    assert(sentTransactionClone.maxFeePerGas)
-    assert(sentTransactionClone.gasLimit)
-    delete sentTransactionClone.maxFeePerGas
-    delete sentTransactionClone.gasLimit
-    assert.deepStrictEqual(sentTransactionClone, {
-      maxPriorityFeePerGas: 13n,
-      nonce: tx.nonce,
-      to: tx.from,
-      value: 0
-    })
-    assert.deepStrictEqual(storage, new Map())
   })
   await t.test('#removeConfirmed()', async t => {
     const tx = {

--- a/test.js
+++ b/test.js
@@ -241,11 +241,10 @@ test('StuckTransactionsCanceller', async t => {
       await Promise.all([
         stuckTransactionsCanceller.cancelOlderThan(0),
         (async () => {
+          // The replacement transaction is "stuck" now
           while (!storage.has(replacementTxs[0].hash)) {
             await timers.setTimeout()
           }
-          // The replacement transaction is "stuck" now
-          assert(storage.has(replacementTxs[0].hash))
           await timers.setTimeout()
           await Promise.all([
             stuckTransactionsCanceller.cancelOlderThan(0),


### PR DESCRIPTION
Fixes situations where the replacement transaction also gets stuck - it will be replaced by a transaction with even higher chances of being accepted.